### PR TITLE
feat: default column visibility state

### DIFF
--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -38,6 +38,7 @@ interface DataTableProps<TData, TValue> {
   pageCount: number
   filterableColumns?: DataTableFilterableColumn<TData>[]
   searchableColumns?: DataTableSearchableColumn<TData>[]
+  visibleColumns?: VisibilityState
 }
 
 export function DataTable<TData, TValue>({
@@ -46,6 +47,7 @@ export function DataTable<TData, TValue>({
   pageCount,
   filterableColumns = [],
   searchableColumns = [],
+  visibleColumns = {},
 }: DataTableProps<TData, TValue>) {
   const router = useRouter()
   const pathname = usePathname()
@@ -78,7 +80,7 @@ export function DataTable<TData, TValue>({
   // Table states
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({})
+    React.useState<VisibilityState>(visibleColumns)
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     []
   )

--- a/src/components/shells/tasks-table-shell.tsx
+++ b/src/components/shells/tasks-table-shell.tsx
@@ -299,6 +299,10 @@ export function TasksTableShell({ data, pageCount }: TasksTableShellProps) {
           title: "Title",
         },
       ]}
+      // visibleColumns={{
+      //   id: false, // Hide the ID column from the UI, but still allow it to be toggled
+      //   createdAt: false, // Hide the createdAt column from the UI, but still allow it to be toggled
+      // }}
     />
   )
 }


### PR DESCRIPTION
**Description**
- This allow passing columns in an object from `tasks-table-shell` to `data-table`
- Setting column to false will still allow it to be toggled

I have commented the code in `tasks-table-shell` as an example of how it should be handled.